### PR TITLE
fix: use-next-public-supabase-anon-key

### DIFF
--- a/utils/supabase/supabase_service.ts
+++ b/utils/supabase/supabase_service.ts
@@ -1,6 +1,6 @@
 import { createClient } from "@supabase/supabase-js";
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || "";
-const supabaseKey = process.env.SUPABASE_ANON_KEY || "";
+const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || "";
 
 export const supabase = createClient(supabaseUrl, supabaseKey);


### PR DESCRIPTION
This PR addresses an issue where the SUPABASE_ANON_KEY environment variable was not correctly set as a public environment variable in the project. The key has now been updated to NEXT_PUBLIC_SUPABASE_ANON_KEY to ensure it is correctly exposed and accessible on the client side.

Changes Made:
Updated the environment variable from SUPABASE_ANON_KEY to NEXT_PUBLIC_SUPABASE_ANON_KEY.
Modified the relevant code to reflect this change, ensuring proper functionality without errors.